### PR TITLE
added ability to read toml based config

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,19 @@ rules =
 
 ```
 
+Or to your `pyproject.toml`:
+```toml
+[tool.coverage.run]
+# Here we specify plugins for coverage to be used:
+plugins = ["coverage_conditional_plugin"]
+
+[tool.coverage.coverage_conditional_plugin.rules]
+# Here we specify our pragma rules:
+py-gte-38 = "sys_version_info >= (3, 8)"
+has-mypy = "is_installed('mypy')"
+```
+
+
 Adapt rules to suit your needs!
 
 

--- a/coverage_conditional_plugin/__init__.py
+++ b/coverage_conditional_plugin/__init__.py
@@ -64,7 +64,7 @@ class _ConditionalCovPlugin(CoveragePlugin):
 
     def _should_be_applied(self, code: str) -> bool:
         """
-        Determens whether some specific marker should be applied or not.
+        Determines whether some specific marker should be applied or not.
 
         Uses ``exec`` on the code you pass with the marker.
         Be sure, that this code is safe.

--- a/coverage_conditional_plugin/__init__.py
+++ b/coverage_conditional_plugin/__init__.py
@@ -43,13 +43,16 @@ class _ConditionalCovPlugin(CoveragePlugin):
             )
 
         except AttributeError:  # toml format
-            rules = (rule for rule in config.get_option(self._rules_opt_name).items())
+            rules = (
+                rule for rule in
+                config.get_option(self._rules_opt_name).items()
+            )
 
         for rule in rules:
             self._process_rule(config, rule)
 
     def _process_rule(
-        self, config: CoverageConfig, rule: Union[str, Tuple[str, str]]
+        self, config: CoverageConfig, rule: Union[str, Tuple[str, str]],
     ) -> None:
         if isinstance(rule, str):
             code, marker = [part.strip() for part in rule.rsplit(':', 1)]

--- a/coverage_conditional_plugin/__init__.py
+++ b/coverage_conditional_plugin/__init__.py
@@ -36,19 +36,21 @@ class _ConditionalCovPlugin(CoveragePlugin):
         Part of the ``coverage`` public API.
         Called right after ``coverage_init`` function.
         """
-        try: # ini format
+        try:  # ini format
             rules = filter(
                 bool,
                 config.get_option(self._rules_opt_name).splitlines(),
             )
 
-        except AttributeError: # toml format
-            rules = (r for r in config.get_option(self._rules_opt_name).items())
+        except AttributeError:  # toml format
+            rules = (rule for rule in config.get_option(self._rules_opt_name).items())
 
         for rule in rules:
             self._process_rule(config, rule)
 
-    def _process_rule(self, config: CoverageConfig, rule: Union[str, Tuple[str, str]]) -> None:
+    def _process_rule(
+        self, config: CoverageConfig, rule: Union[str, Tuple[str, str]]
+    ) -> None:
         if isinstance(rule, str):
             code, marker = [part.strip() for part in rule.rsplit(':', 1)]
             code = code[1:-1]  # removes quotes

--- a/coverage_conditional_plugin/__init__.py
+++ b/coverage_conditional_plugin/__init__.py
@@ -36,16 +36,28 @@ class _ConditionalCovPlugin(CoveragePlugin):
         Part of the ``coverage`` public API.
         Called right after ``coverage_init`` function.
         """
-        rules = filter(
-            bool,
-            config.get_option(self._rules_opt_name).splitlines(),
-        )
+        try: # ini format
+            rules = filter(
+                bool,
+                config.get_option(self._rules_opt_name).splitlines(),
+            )
+
+        except AttributeError: # toml format
+            rules = (r for r in config.get_option(self._rules_opt_name).items())
+
         for rule in rules:
             self._process_rule(config, rule)
 
-    def _process_rule(self, config: CoverageConfig, rule: str) -> None:
-        code, marker = [part.strip() for part in rule.rsplit(':', 1)]
-        if self._should_be_applied(code[1:-1]):  # removes quotes
+    def _process_rule(self, config: CoverageConfig, rule: Union[str, Tuple[str, str]]) -> None:
+        if isinstance(rule, str):
+            code, marker = [part.strip() for part in rule.rsplit(':', 1)]
+            code = code[1:-1]  # removes quotes
+        elif isinstance(rule, tuple):
+            marker = rule[0]
+            code = rule[1]
+        else:
+            raise ValueError("Invalid type for 'rule'.")
+        if self._should_be_applied(code):
             self._ignore_marker(config, marker)
 
     def _should_be_applied(self, code: str) -> bool:

--- a/coverage_conditional_plugin/__init__.py
+++ b/coverage_conditional_plugin/__init__.py
@@ -2,7 +2,7 @@ import os
 import sys
 import traceback
 from importlib import import_module
-from typing import ClassVar, Dict, Optional, Tuple
+from typing import ClassVar, Dict, Optional, Tuple, Union
 
 import pkg_resources
 from coverage import CoveragePlugin

--- a/test_project/pyproject.toml
+++ b/test_project/pyproject.toml
@@ -1,0 +1,7 @@
+[tool.coverage.run]
+plugins = ["coverage_conditional_plugin"]
+
+[tool.coverage.coverage_conditional_plugin.rules]
+py-gte-36 = "sys_version_info >= (3, 6)"
+py-gte-37 = "sys_version_info >= (3, 7)"
+py-gte-38 = "sys_version_info >= (3, 8)"

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -37,10 +37,10 @@ def test_integration(cov, capsys):
     assert coverage['totals']['missing_lines'] == 1
 
 
-@pytest.mark.parametrize("configfile", [".coveragerc", "pyproject.toml"])
+@pytest.mark.parametrize('configfile', ['.coveragerc', 'pyproject.toml'])
 def test_config_file_parsing(configfile):
     """Ensures that coverage is executed correctly."""
-    config_file_path = Path(__file__).parents[1]/'test_project'/configfile
+    config_file_path = Path(__file__).parents[1] / 'test_project' / configfile
 
     cov = Coverage(config_file=str(config_file_path))
     assert cov.config.config_file == str(config_file_path)
@@ -49,4 +49,4 @@ def test_config_file_parsing(configfile):
     cov.start()
     cov.stop()
 
-    assert f"py-gte-3{sys.version_info[1]}" in cov.config.exclude_list
+    assert 'py-gte-3{}'.format(sys.version_info[1]) in cov.config.exclude_list

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -49,4 +49,7 @@ def test_config_file_parsing(configfile):
     cov.start()
     cov.stop()
 
-    assert 'py-gte-3{}'.format(sys.version_info[1]) in cov.config.exclude_list
+    assert (
+        'py-gte-3{minor_ver}'.format(minor_ver=sys.version_info[1])
+        in cov.config.exclude_list
+    )

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -2,6 +2,10 @@
 
 import json
 import sys
+from pathlib import Path
+
+import pytest
+from coverage import Coverage
 
 from test_project.example import (
     always,
@@ -31,3 +35,18 @@ def test_integration(cov, capsys):
     ) == _EXCUDED_LINES
     assert int(coverage['totals']['percent_covered']) >= 80
     assert coverage['totals']['missing_lines'] == 1
+
+
+@pytest.mark.parametrize("configfile", [".coveragerc", "pyproject.toml"])
+def test_config_file_parsing(configfile):
+    """Ensures that coverage is executed correctly."""
+    config_file_path = Path(__file__).parents[1]/'test_project'/configfile
+
+    cov = Coverage(config_file=str(config_file_path))
+    assert cov.config.config_file == str(config_file_path)
+    assert cov.config.plugins == ['coverage_conditional_plugin']
+
+    cov.start()
+    cov.stop()
+
+    assert f"py-gte-3{sys.version_info[1]}" in cov.config.exclude_list


### PR DESCRIPTION
`coverage` supports `pyproject.toml` as config source. This plugin cannot use the config it gets from `coverage` when `pyproject.toml` is used.

I adjusted the code to be able to use both configs.

In  `pyproject.toml` you would write it like this:
```toml
[tool.coverage.coverage_conditional_plugin.rules]
py-gte-38 = "sys_version_info >= (3, 8)"
has-mypy = "is_installed('mypy')"
```