### PR TITLE
Use poetry_core as build-system for PEP517 compliance

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
-requires = ["poetry>=1.0"]
-build-backend = "poetry.masonry.api"
+requires = ["poetry_core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"
 
 
 [tool.nitpick]


### PR DESCRIPTION
pyproject.toml:
Declare build-system as described by poetry's upstream documentation
(https://python-poetry.org/docs/pyproject/#poetry-and-pep-517) to be
PEP517 compliant.

Fixes #155 