### PR TITLE
Add test files to sdist tarball

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,10 @@ license = "MIT"
 
 authors = []
 
+include = [
+  {path = 'tests/*', format = 'sdist'},
+  {path = 'test_project/*', format = 'sdist'},
+]
 readme = "README.md"
 
 repository = "https://github.com/wemake-services/coverage-conditional-plugin"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,8 @@ license = "MIT"
 
 authors = []
 
+# This is required for source distributions, like the one 
+# used for Alpine linux. See #157
 include = [
   {path = 'tests/*', format = 'sdist'},
   {path = 'test_project/*', format = 'sdist'},


### PR DESCRIPTION
pyproject.toml:
Add tests and test_project directories to sdist tarball.

Fixes #153 